### PR TITLE
Fixes #1

### DIFF
--- a/common/build-defaults.properties
+++ b/common/build-defaults.properties
@@ -3,4 +3,4 @@ compiler.generate.no.warnings=off
 compiler.args=-Xlint
 compiler.max.memory=128m
 compiler.source.version=1.7
-junit.jar=/Users/vincenzoferme/.m2/repository/junit/junit/4.4/junit-4.4.jar
+#junit.jar=/Users/vincenzoferme/.m2/repository/junit/junit/4.4/junit-4.4.jar

--- a/driver/build-defaults.properties
+++ b/driver/build-defaults.properties
@@ -3,5 +3,5 @@ compiler.generate.no.warnings=off
 compiler.args=
 compiler.max.memory=128m
 compiler.source.version=1.7
-env.JDK_HOME=/Library/Java/JavaVirtualMachines/jdk1.7.0_51.jdk/Contents/Home
-junit.jar=/Users/vincenzoferme/.m2/repository/junit/junit/4.4/junit-4.4.jar
+#env.JDK_HOME=/Library/Java/JavaVirtualMachines/jdk1.7.0_51.jdk/Contents/Home
+#junit.jar=/Users/vincenzoferme/.m2/repository/junit/junit/4.4/junit-4.4.jar

--- a/driver/build.xml
+++ b/driver/build.xml
@@ -40,7 +40,7 @@
 
     <path id="class.path">
         <fileset dir="lib" includes="*.jar"/>
-        <fileset dir="${env.JDK_HOME}/lib" includes="tools.jar"/>
+        <fileset dir="${java.home}/lib" includes="tools.jar"/>
     </path>
 
     <path id="test.class.path">

--- a/harness/build-defaults.properties
+++ b/harness/build-defaults.properties
@@ -3,5 +3,5 @@ compiler.generate.no.warnings=off
 compiler.args=
 compiler.max.memory=128m
 compiler.source.version=1.7
-env.JDK_HOME=/Library/Java/JavaVirtualMachines/jdk1.7.0_51.jdk/Contents/Home
-junit.jar=/Users/vincenzoferme/.m2/repository/junit/junit/4.4/junit-4.4.jar
+#env.JDK_HOME=/Library/Java/JavaVirtualMachines/jdk1.7.0_51.jdk/Contents/Home
+#junit.jar=/Users/vincenzoferme/.m2/repository/junit/junit/4.4/junit-4.4.jar

--- a/harness/build.xml
+++ b/harness/build.xml
@@ -44,7 +44,7 @@
     <path id="class.path">
         <fileset dir="lib" includes="*.jar"/>
         <fileset dir="../stage/master/common/lib" includes="*.jar"/>
-        <fileset dir="${env.JDK_HOME}/lib" includes="tools.jar"/>
+        <fileset dir="${java.home}/lib" includes="tools.jar"/>
     </path>
 
     <path id="test.class.path">


### PR DESCRIPTION
The path to `JAVA_HOME` doesn't need to be specified anymore, provided that the JRE is set properly in Eclipse.
