### PR TITLE
Update to fabancli deploy; added stage folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ harness/lib/fabancommon.jar
 stage/build.properties
 
 nightly/
+stage/
+stage/master/
 stage/ant/
 stage/bin/
 stage/config/
@@ -20,6 +22,7 @@ stage/lib/fabanagents.jar
 stage/lib/fabancommon.jar
 stage/lib/fabandriver.jar
 stage/master/conf/Catalina/localhost/faban.xml
+stage/master/conf/tomcat-users.xml
 stage/master/webapps/faban.war
 stage/master/webapps/faban/
 stage/release

--- a/harness/src/com/sun/faban/harness/util/CLI.java
+++ b/harness/src/com/sun/faban/harness/util/CLI.java
@@ -174,11 +174,14 @@ public class CLI {
             		DeployLogic dl = new DeployLogic(user, password, master, jarFile);
             		
             		try {
-            			dl.deploy();
+            			final DeployStatus.CODE status = dl.deploy();
+            			System.out.println(status);
             		} catch(DeployException e) {
-            			System.err.println("[Deploy]: " + e);
+            			//Print exit status to stdout 
+            			//to act accordingly from caller
+            			System.out.println(e.status);
             			System.exit(1);
-            		}
+            		} 
             	} else {
             		System.err.println("[Deploy] Please provide a benchmark to deploy");
             		printUsage();

--- a/harness/src/com/sun/faban/harness/util/DeployException.java
+++ b/harness/src/com/sun/faban/harness/util/DeployException.java
@@ -27,7 +27,9 @@ package com.sun.faban.harness.util;
  * Signifies a deployment exception
  */
 public class DeployException extends Exception {
-
+	
+	
+	public final DeployStatus.CODE status;
     /**
      * Constructs a new exception with the specified detail message.  The
      * cause is not initialized, and may subsequently be initialized by
@@ -38,8 +40,14 @@ public class DeployException extends Exception {
      */
     public DeployException(String message) {
         super(message);    //To change body of overridden methods use File | Settings | File Templates.
+        this.status = DeployStatus.CODE.UNDEFINED_ERROR;
     }
-
+    
+    public DeployException(DeployStatus.CODE status, String message) {
+    	super(message);
+    	this.status = status;
+    }
+    
     /**
      * Constructs a new exception with the specified detail message and
      * cause.  <p>Note that the detail message associated with
@@ -55,7 +63,18 @@ public class DeployException extends Exception {
      * @since 1.4
      */
     public DeployException(String message, Throwable cause) {
+    	super(message, cause);    //To change body of overridden methods use File | Settings | File Templates.
+    	this.status = DeployStatus.CODE.UNDEFINED_ERROR;
+    }
+    
+    public DeployException(DeployStatus.CODE status, Throwable cause) {
+    	super(cause);
+    	this.status = status;
+    }
+    
+    public DeployException(DeployStatus.CODE status, String message, Throwable cause) {
         super(message, cause);    //To change body of overridden methods use File | Settings | File Templates.
+        this.status = status;
     }
 
     /**
@@ -74,5 +93,6 @@ public class DeployException extends Exception {
      */
     public DeployException(Throwable cause) {
         super(cause);    //To change body of overridden methods use File | Settings | File Templates.
+        this.status = DeployStatus.CODE.UNDEFINED_ERROR;
     }
 }

--- a/harness/src/com/sun/faban/harness/util/DeployStatus.java
+++ b/harness/src/com/sun/faban/harness/util/DeployStatus.java
@@ -1,0 +1,33 @@
+package com.sun.faban.harness.util;
+
+/***
+ * A class representing the status of a deploy request
+ * through a descriptive code:
+ * 
+ * 0: if the benchmark is correctly deployed on the harness
+ *    (201 CREATED)
+ * 1: if the file is not found on the user's system
+ *    (FileNotFoundException)
+ * 2: a more generic I/O exception
+ *    (IOException)
+ * 3: a conflict (the benchmark is running or scheduled to be run)
+ * 	  (409 CONFLICT)
+ * 4: benchmark not acceptable (not a jar, name with dots)
+ *    (406 NOT ACCEPTABLE)
+ * 5: other, undefined error
+ * 6: no benchmark specified as argument to the fabancli
+ * 
+ * The choice for this implementation is that we need to return a
+ * descriptive value in range 0-255 to the ./fabancli shell script      
+ *
+ * @author simonedavico
+ *
+ */
+public class DeployStatus {
+
+	public static enum CODE { DEPLOYED, FILE_NOT_FOUND, 
+					   IO_EXCEPTION, CONFLICT, 
+					   NOT_ACCEPTABLE, UNDEFINED_ERROR,
+					   NO_BENCHMARK_SPECIFIED };
+
+}


### PR DESCRIPTION
The `fabancli` now returns a `status` representing the outcome of the deploy operation on the harness.

Possible values:
- `DEPLOYED`: the jar file has been correctly deployed;
- `FILE_NOT_FOUND`: the jar file was not found on the user file system;
- `IO_EXCEPTION`: an IO error occurred;
- `CONFLICT`: occurs if the deployed benchmark is running or scheduled to be run;
-  `NO_BENCHMARK_SPECIFIED`: should never occur in principle. Happens if `deploy` gets called with a `null` argument;
- `UNDEFINED_ERROR`: in case some other error occurs.
